### PR TITLE
AUT-1969 Convert to NPM scoped package naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,27 @@ Cloudentity Auth JS client for Javascript Single Page Apps.
 ### Script tag
 
 ```
-<script src="cloudentity-auth-js.js"></script>
+<script src="cloudentity-auth.js"></script>
 ```
 
 ### Node.js style
 
 ```javascript
-const CloudentityAuthJs = require('cloudentity-auth-js');
+const CloudentityAuth = require('@cloudentity/auth');
 ```
 
 ### ES6 import
 
 ```javascript
-import CloudentityAuthJs from 'cloudentity-auth-js';
+import CloudentityAuth from '@cloudentity/auth';
 ```
 
 ## Usage
 
-1. First – create and configure CloudentityAuthJs:
+1. First – create and configure CloudentityAuth:
 
   ```javascript
-  var cloudentity = new CloudentityAuthJs({
+  var cloudentity = new CloudentityAuth({
       domain: 'your-domain', // e.g. 'example.demo.cloudentity.com'
       tenantId: 'your-tenant-id',
       authorizationServerId: 'your-authorization-server-id',
@@ -41,7 +41,7 @@ import CloudentityAuthJs from 'cloudentity-auth-js';
   });
   ```
 
-  > Note: By default, PKCE authorization flow is used. Implicit flow can be used by including `{implicit: true}` in the configuration object passed into CloudentityAuthJs (this is not recommended).
+  > Note: By default, PKCE authorization flow is used. Implicit flow can be used by including `{implicit: true}` in the configuration object passed into CloudentityAuth (this is not recommended).
 
 2. To check if there's an OAuth response and parse it:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloudentity-auth-js",
+  "name": "@cloudentity/auth",
   "version": "1.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "cloudentity-auth-js",
+  "name": "@cloudentity/auth",
   "version": "1.0.0-beta.0",
   "description": "",
-  "main": "dist/cloudentity-auth-js.js",
+  "main": "dist/cloudentity-auth.js",
   "scripts": {
     "clean": "rimraf dist",
     "webpack": "webpack",
@@ -16,9 +16,6 @@
     "url": ""
   },
   "private": false,
-  "publishConfig": {
-    "registry": "https://artifactory.syntegrity.com/api/npm/npm-local"
-  },
   "dependencies": {
     "babel-runtime": "6.26.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-import CloudentityAuthJs from './CloudentityAuthJs';
+import CloudentityAuth from './CloudentityAuth';
 
-module.exports =  CloudentityAuthJs; // not 'export default' because of issues with webpack's UMD export
+module.exports =  CloudentityAuth; // not 'export default' because of issues with webpack's UMD export

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -51,7 +51,7 @@ export const validateObject = (validators) => {
   return function (configObject) {
     const allResults = getAllResults(validators, configObject);
     if (allResults.length) {
-      let errorMessage = 'CloudentityAuthJs: ';
+      let errorMessage = 'CloudentityAuth: ';
       allResults.forEach((r, i) => i === allResults.length - 1 ? errorMessage += r.message : errorMessage += `${r.message}, `);
       return errorMessage;
     } else {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,13 +10,13 @@ module.exports = env => {
   return {
     // devtool: 'source-map',
     entry: {
-      'cloudentity-auth-js': here('src/index.js'),
+      'cloudentity-auth': here('src/index.js'),
     },
     output: {
       filename: '[name].js',
       path: here('dist'),
       publicPath: '/',
-      library: 'CloudentityAuthJs',
+      library: 'CloudentityAuth',
       libraryTarget: 'umd',
       umdNamedDefine: true
     },


### PR DESCRIPTION
Change package name on NPM from `cloudentity-auth-js` -> `@cloudentity/auth`

- This fixes an issue with NPM style guidelines, which frowns on using 'js' in a package name, since 'js' is implied (it is fine to keep Github repository name as 'cloudentity-auth-js', but package name should not have 'js' suffix)

- Scoped package names (beginning with `@cloudentity` and ending with `/package-name`) are more suitable for a company/organization like Cloudentity, which may publish multiple packages under the umbrella of the same organization

- Scoped package names also make it easier for different devs with different NPM accounts in an organization to contribute to a single organization's public repository of NPM packages