### PR TITLE
AUT-1991 Allow configuring base URL including protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ import CloudentityAuth from '@cloudentity/auth';
 
   ```javascript
   var cloudentity = new CloudentityAuth({
-      domain: 'your-domain', // e.g. 'example.demo.cloudentity.com'
+      domain: 'your-domain', // e.g. 'example.demo.cloudentity.com.' Recommended; always generates URLs with 'https' protocol.
+      // baseUrl: optional alternative to 'domain.' Protocol required, e.g. 'https://example.demo.cloudentity.com.'
+      // In situations where protocol may dynamically resolve to 'http' rather than 'https' (for example in dev mode), use 'baseUrl' rather than 'domain'.
       tenantId: 'your-tenant-id',
       authorizationServerId: 'your-authorization-server-id',
       clientId: 'your-client-id',
@@ -40,6 +42,14 @@ import CloudentityAuth from '@cloudentity/auth';
       idTokenName: 'your_org_access_token', // optional; defaults to '{tenantId}_{authorizationServerId}_id_token'
   });
   ```
+
+  In most cases, either `domain` **or** `baseUrl` can be used to generate all required URLs. However, it is possible to supply the full URL in the config for each use case:
+  - Authorization: `authorizationUri`
+  - Token: `tokenUri`
+  - User Info: `userInfoUri`
+  - Logout via Revoke Token: `logoutUri`
+
+  Be aware that if using these custom URL values, neither `domain` nor `baseUrl` values should be supplied in the config; otherwise, they will take priority (`domain` takes highest priority in such cases).
 
   > Note: By default, PKCE authorization flow is used. Implicit flow can be used by including `{implicit: true}` in the configuration object passed into CloudentityAuth (this is not recommended).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudentity/auth",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudentity/auth",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "",
   "main": "dist/cloudentity-auth.js",
   "scripts": {

--- a/src/CloudentityAuth.js
+++ b/src/CloudentityAuth.js
@@ -23,6 +23,9 @@ const optionsSpec = {
   domain: [
     {test: optionalString, message: '\'domain\' [non-empty string] required if option value given'}
   ],
+  baseUrl: [
+    {test: optionalString, message: '\'baseUrl\' [non-empty string] required if option value given'}
+  ],
   authorizationUri: [
     {test: optionalString, message: '\'authorizationUri\' [non-empty string] required if option value given'}
   ],
@@ -326,17 +329,20 @@ class CloudentityAuth {
       throw new Error(error);
     }
 
-    options.authorizationUri = options.domain
-      ? `https://${options.domain}/${options.tenantId ? options.tenantId + '/' : ''}${options.authorizationServerId ? options.authorizationServerId + '/' : ''}oauth2/authorize`
+    const useDefaultUriFormat = options.domain || options.baseUrl;
+    const baseUrl = options.domain ? `https://${options.domain}` : options.baseUrl;
+
+    options.authorizationUri = useDefaultUriFormat
+      ? `${baseUrl}/${options.tenantId ? options.tenantId + '/' : ''}${options.authorizationServerId ? options.authorizationServerId + '/' : ''}oauth2/authorize`
       : options.authorizationUri;
-    options.tokenUri = options.domain
-      ? `https://${options.domain}/${options.tenantId ? options.tenantId + '/' : ''}${options.authorizationServerId ? options.authorizationServerId + '/' : ''}oauth2/token`
+    options.tokenUri = useDefaultUriFormat
+      ? `${baseUrl}/${options.tenantId ? options.tenantId + '/' : ''}${options.authorizationServerId ? options.authorizationServerId + '/' : ''}oauth2/token`
       : options.tokenUri;
-    options.userInfoUri = options.domain
-      ? `https://${options.domain}/${options.tenantId ? options.tenantId + '/' : ''}${options.authorizationServerId ? options.authorizationServerId + '/' : ''}userinfo`
+    options.userInfoUri = useDefaultUriFormat
+      ? `${baseUrl}/${options.tenantId ? options.tenantId + '/' : ''}${options.authorizationServerId ? options.authorizationServerId + '/' : ''}userinfo`
       : options.userInfoUri;
-    options.logoutUri = options.domain
-      ? `https://${options.domain}/${options.tenantId ? options.tenantId + '/' : ''}${options.authorizationServerId ? options.authorizationServerId + '/' : ''}oauth2/revoke`
+    options.logoutUri = useDefaultUriFormat
+      ? `${baseUrl}/${options.tenantId ? options.tenantId + '/' : ''}${options.authorizationServerId ? options.authorizationServerId + '/' : ''}oauth2/revoke`
       : options.logoutUri;
 
     return options;


### PR DESCRIPTION
- Add `baseUrl` config option as alternative to `domain`.
- e.g. `baseUrl`: `https://example.foo.com`, vs. `domain`: `example.foo.com`
- The `baseUrl` option is for cases where protocol (`http` vs. `https`) may be dynamic, e.g. due to running in development mode.
- Add documentation to README explaining new options, addition of info about hard-coded URL options