### PR TITLE
AUT-2936 Flag to disable library automatically setting access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Added
+- Flag to disable library automatically setting access token, allowing client app more fine-grained control
+
 ## [1.0.0] - 2020-12-02
 ### Changed
 - Refactor to use Cloudentity ACP and PKCE as default authorization method

--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ import CloudentityAuth from '@cloudentity/auth';
   // (synchronous, returns String if token is present and not expired; otherwise returns null)
   ```
 
+  - In some cases, the client app developer may want to set multiple access tokens for the same user based on custom logic, e.g. to set action-specific access tokens associated with specific scopes, in addition to the access token initially set during authentication. To do this, disable the library setting access tokens in the auth config:
+
+  ```javascript
+  var cloudentity = new CloudentityAuth({
+      // other settings...
+      //
+      letClientSetAccessToken: true // with this flag enabled, client app must handle setting all access tokens based on auth response
+      accessTokenName: 'your_org_access_token', // it is still possible to specify an access token key value that will always be deleted on logout
+  });
+  ```
+
 ### Legacy browser support
 
 To use with SPAs that must support Microsoft IE11 or Edge Legacy:

--- a/src/CloudentityAuth.js
+++ b/src/CloudentityAuth.js
@@ -47,6 +47,9 @@ const optionsSpec = {
   scopes: [
     {test: stringOrEmptyArray, message: '\'scopes\' [array of strings or empty array] option is required'}
   ],
+  letClientSetAccessToken: [
+    {test: optionalBoolean, message: '\'letClientSetAccessToken\' [boolean] required if option value given'}
+  ],
   accessTokenName: [
     {test: optionalString, message: '\'accessTokenName\' [non-empty string] required if option value given'}
   ],
@@ -169,7 +172,9 @@ class CloudentityAuth {
         .then(CloudentityAuth._handleApiResponse)
         .then(data => {
           this.cleanUpPkceLocalStorageItems();
-          CloudentityAuth._setAccessToken(this.options, data.access_token);
+          if (!this.options.letClientSetAccessToken) {
+            CloudentityAuth._setAccessToken(this.options, data.access_token);
+          }
           if (data.id_token) {
             CloudentityAuth._setIdToken(this.options, data.id_token);
           }


### PR DESCRIPTION
Flag to disable library automatically setting access token, which allows client app more fine-grained control. This is necessary in situations where the client app is setting multiple action-specific action tokens for the same logged-in user.