### PR TITLE
AUT-8417 Add tokenExchange method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 ### Added
+- Token exchange method
 - Flag to disable library automatically setting access token, allowing client app more fine-grained control
 - idp_hint, login_hint support in authorize
 - Dynamic redirect URI support

--- a/README.md
+++ b/README.md
@@ -163,19 +163,22 @@ import CloudentityAuth from '@cloudentity/auth';
 
   ```javascript
   cloudentity.tokenExchange({
-    subjectToken: 'token', // required, this is usually the access_token
-    customFields: { // optional but usually necessary to configure
-      custom_field: 'value', // except for 'scope', values for custom fields must be string
+    subjectToken: 'token', // required, this is usually the current access_token
+    // clientId: 'client-id', // optional, not necessary unless using different token exchange client than globally configured client
+    // clientSecret: 'client-secret', // optional, ONLY use on server-side application where secret is not exposed in browser
+    customFields: { // optional, but usually necessary to configure for common use cases
+      custom_field_1: 'value1', // except for 'scope', values for custom fields must be string
+      custom_field_2: 'value2',
       scope: ['scope1', 'scope2'] // value of 'scope' can be an array of strings, OR can be a string with spaces separating scopes, e.g. 'scope1 scope2'
     },
-    customHeaders: { // optional
+    customHeaders: { // optional, adds custom http headers to outgoing request
       'example-header': 'value'
     },
     setAccessToken: true // optional, defaults to 'false'. If set to 'true', token resulting from token exchange request will replace previous access_token in browser local storage.
   });
   ```
 
-  Note: Client ID value is sourced from the global config. If token exchange request is used in trusted server-side application, add value for `client_secret` in 'customFields'; if used on client side, do NOT add `client_secret`, but ensure that feature flag for token exchange requests on client side is enabled in your ACP tenant.
+  Note: Client ID value is sourced from the global config by default. `clientId` config can be added to request as shown above to use a different ID than that of the global client. Only if token exchange request is used in server-side application, add config for `clientSecret` as well; if used on UI client side, do NOT add `clientSecret`, but ensure that feature flag for token exchange requests on client side is enabled in your ACP tenant.
 
 ### Legacy browser support
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ import CloudentityAuth from '@cloudentity/auth';
     customHeaders: { // optional, adds custom http headers to outgoing request
       'example-header': 'value'
     },
-    setAccessToken: true // optional, defaults to 'false'. If set to 'true', token resulting from token exchange request will replace previous access_token in browser local storage.
+    setAccessToken: false, // optional, defaults to 'false'. If set to 'true', access token resulting from token exchange request will replace previous access_token in browser local storage.
+    setIdToken: false // optional, defaults to 'false'. If set to 'true', ID token resulting from token exchange request will replace previous id_token in browser local storage.
   });
   ```
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ import CloudentityAuth from '@cloudentity/auth';
   It's possible to pass `prompt` param to authorization request:
 
   ```javascript
-    cloudentity.authorize({prompt: "login"});
+    cloudentity.authorize({prompt: 'login'});
   ```
 
 4. For simple logout:
@@ -158,6 +158,24 @@ import CloudentityAuth from '@cloudentity/auth';
       accessTokenName: 'your_org_access_token', // it is still possible to specify an access token key value that will always be deleted on logout
   });
   ```
+
+  - To make a token exchange request:
+
+  ```javascript
+  cloudentity.tokenExchange({
+    subjectToken: 'token', // required, this is usually the access_token
+    customFields: { // optional but usually necessary to configure
+      custom_field: 'value', // except for 'scope', values for custom fields must be string
+      scope: ['scope1', 'scope2'] // value of 'scope' can be an array of strings, OR can be a string with spaces separating scopes, e.g. 'scope1 scope2'
+    },
+    customHeaders: { // optional
+      'example-header': 'value'
+    },
+    setAccessToken: true // optional, defaults to 'false'. If set to 'true', token resulting from token exchange request will replace previous access_token in browser local storage.
+  });
+  ```
+
+  Note: Client ID value is sourced from the global config. If token exchange request is used in trusted server-side application, add value for `client_secret` in 'customFields'; if used on client side, do NOT add `client_secret`, but ensure that feature flag for token exchange requests on client side is enabled in your ACP tenant.
 
 ### Legacy browser support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudentity/auth",
-  "version": "2.0.5-beta.0",
+  "version": "2.0.5-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudentity/auth",
-      "version": "2.0.5-beta.0",
+      "version": "2.0.5-beta.2",
       "devDependencies": {
         "babel-cli": "6.26.0",
         "babel-core": "6.26.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudentity/auth",
-  "version": "2.0.5-beta.2",
+  "version": "2.0.5-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudentity/auth",
-      "version": "2.0.5-beta.2",
+      "version": "2.0.5-beta.3",
       "devDependencies": {
         "babel-cli": "6.26.0",
         "babel-core": "6.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudentity/auth",
-  "version": "2.0.5-beta.2",
+  "version": "2.0.5-beta.3",
   "description": "",
   "main": "dist/cloudentity-auth.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudentity/auth",
-  "version": "2.0.5-beta.0",
+  "version": "2.0.5-beta.2",
   "description": "",
   "main": "dist/cloudentity-auth.js",
   "scripts": {

--- a/src/CloudentityAuth.js
+++ b/src/CloudentityAuth.js
@@ -16,6 +16,9 @@ const optionsSpec = {
   clientId: [
     {test: notEmptyString, message: '\'cliendId\' [non-empty string] option is required'}
   ],
+  clientSecret: [
+    {test: optionalString, message: '\'clientSecret\' [non-empty string] required if option value given'}
+  ],
   tenantId: [
     {test: optionalString, message: '\'tenantId\' [non-empty string] option is required'}
   ],
@@ -306,11 +309,6 @@ class CloudentityAuth {
         }
 
         if (data.id_token && options.setIdToken) {
-          if (CloudentityAuth._getValueFromToken('nonce', data.id_token) !== getLocalStorageItem(`${this.options.tenantId}_${this.options.authorizationServerId}_token_id_nonce`)) {
-            this.cleanUpPkceLocalStorageItems();
-            return Promise.reject({error: ERRORS.UNAUTHORIZED});
-          }
-
           CloudentityAuth._setIdToken(this.options, data.id_token);
         }
 

--- a/src/CloudentityAuth.js
+++ b/src/CloudentityAuth.js
@@ -283,9 +283,12 @@ class CloudentityAuth {
 
     const customFieldsToUrlEncodedString = CloudentityAuth._optionsToUrlEncodedString(customFields);
 
+    const clientSecret = options.clientSecret || this.options.clientSecret;
+
     const tokenExchangeData = 'grant_type=urn:ietf:params:oauth:grant-type:token-exchange'
       + '&subject_token=' + encodeURIComponent(options.subjectToken)
-      + '&client_id=' + encodeURIComponent(this.options.clientId)
+      + '&client_id=' + encodeURIComponent(options.clientId || this.options.clientId)
+      + (clientSecret ? '&client_secret=' + encodeURIComponent(clientSecret) : '')
       + (customFieldsToUrlEncodedString && '&' + customFieldsToUrlEncodedString);
 
     return global.window.fetch(this.options.tokenUri, {


### PR DESCRIPTION
## Jira task - [AUT-8417](https://cloudentity.atlassian.net/browse/AUT-8417)

## Release Notes Description

- Add support for token exchange requests using new `tokenExchange` method.

Example of a token exchange request with configuration options:

  ```javascript
  cloudentity.tokenExchange({
    subjectToken: 'token', // required, this is usually the access_token
    customFields: { // optional but usually necessary to configure
      custom_field: 'value', // except for 'scope', values for custom fields must be string
      scope: ['scope1', 'scope2'] // value of 'scope' can be an array of strings, OR can be a string with spaces separating scopes, e.g. 'scope1 scope2'
    },
    customHeaders: { // add optional custom http headers
      'example-header': 'value'
    },
    setAccessToken: true // optional, defaults to 'false'. If set to 'true', token resulting from token exchange request will replace previous access_token in browser local storage.
  });
  ```

**Note:** Client ID value is sourced from the global config. If token exchange request is used in trusted server-side application, add value for `client_secret` in 'customFields'; if used on client side, do NOT add `client_secret`, but ensure that feature flag for token exchange requests on client side is enabled in your ACP tenant.

[AUT-8417]: https://cloudentity.atlassian.net/browse/AUT-8417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ